### PR TITLE
Fix GenerateSW plugin detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,10 +61,8 @@ const addWebpackAlias = alias => config => {
 };
 
 const adjustWorkbox = adjust => config => {
-  const { GenerateSW } = require("workbox-webpack-plugin");
-
   config.plugins.forEach(p => {
-    if (p instanceof GenerateSW) {
+    if (p.constructor.name === "GenerateSW") {
       adjust(p.config);
     }
   });


### PR DESCRIPTION
The `p instanceof GenerateSW` check was returning `false` for me on the GenerateSW plugin, so the `adjustWorkbox` adjustment was never being made. Changing that check to `p.constructor.name === "GenerateSW"` made it work as expected.

I'm actually not even sure why `p instanceof GenerateSW` wasn't working, I would have expected it to.