### PR TITLE
feat: add watchAll plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const addBundleVisualizer = (options = {}, behindFlag = false) => config => {
 
   // if behindFlag is set to true, the report will be created only if
   // the `--analyze` flag is added to the `yarn build` command
-  if (behindFlag ? process.argv.includes('--analyze') : true) {
+  if (behindFlag ? process.argv.includes("--analyze") : true) {
     config.plugins.push(
       new BundleAnalyzerPlugin(
         Object.assign(
@@ -92,11 +92,10 @@ const useEslintRc = () => config => {
   eslintRule.use[0].options.useEslintrc = true;
   delete eslintRule.use[0].options.baseConfig;
 
-  const rules = config.module.rules.map(
-    r =>
-      r.use && r.use.some(u => u.options && u.options.useEslintrc !== void 0)
-        ? eslintRule
-        : r
+  const rules = config.module.rules.map(r =>
+    r.use && r.use.some(u => u.options && u.options.useEslintrc !== void 0)
+      ? eslintRule
+      : r
   );
   config.module.rules = rules;
 
@@ -110,16 +109,15 @@ const enableEslintTypescript = () => config => {
 
   eslintRule.test = /\.([j,t]sx?|mjs)$/;
 
-  const rules = config.module.rules.map(
-    r =>
-      r.use && r.use.some(u => u.options && u.options.useEslintrc !== void 0)
-        ? eslintRule
-        : r
+  const rules = config.module.rules.map(r =>
+    r.use && r.use.some(u => u.options && u.options.useEslintrc !== void 0)
+      ? eslintRule
+      : r
   );
   config.module.rules = rules;
 
   return config;
-}
+};
 
 const useBabelRc = () => config => {
   const babelLoaderFilter = rule =>
@@ -164,6 +162,27 @@ const fixBabelImports = (libraryName, options) =>
     `fix-${libraryName}-imports`
   ]);
 
+// Use this helper to override the webpack dev server settings
+//  it works just like the `override` utility
+const overrideDevServer = (...plugins) => configFunction => (
+  proxy,
+  allowedHost
+) => {
+  const config = configFunction(proxy, allowedHost);
+  const updatedConfig = override(...plugins)(config);
+  return updatedConfig;
+};
+
+// to be used inside `overrideDevServer`, makes CRA watch all the folders
+// included `node_modules`, useful when you are working with linked packages
+// usage: `yarn start --watch-all`
+const watchAll = () => config => {
+  if (process.argv.includes("--watch-all")) {
+    delete config.watchOptions;
+  }
+  return config;
+};
+
 module.exports = {
   override,
   addBundleVisualizer,
@@ -176,5 +195,7 @@ module.exports = {
   enableEslintTypescript,
   addBabelPlugins,
   fixBabelImports,
-  useBabelRc
+  useBabelRc,
+  overrideDevServer,
+  watchAll,
 };

--- a/readme.md
+++ b/readme.md
@@ -117,9 +117,8 @@ Adds the bundle visualizer plugin to your webpack config. Be sure to have `webpa
 You can hide this plugin behind a command line flag (`--analyze`) by passing `true` as second argument.
 
 ```js
-addBundleVisualizer({}, true)
+addBundleVisualizer({}, true);
 ```
-
 
 ### useBabelRc()
 
@@ -198,3 +197,36 @@ module.exports = override(
 ## MobX Users
 
 If you want CRA 2 to work with MobX, use the `addDecoratorsLegacy` and `disableEsLint`.
+
+## Override dev server configuration
+
+To override the webpack dev server configuration, you can use the `overrideDevServer` utility:
+
+```js
+const {
+  override,
+  disableEsLint,
+  overrideDevServer,
+  watchAll
+} = require("customize-cra");
+
+module.exports = {
+  webpack: override(
+    // usual webpack plugin
+    disableEsLint()
+  ),
+  devServer: overrideDevServer(
+    // dev server plugin
+    watchAll()
+  )
+};
+```
+
+### watchAll()
+
+When applied, CRA will watch all the project's files, included `node_modules`.  
+To use it, just apply it and run the dev server with `yarn start --watch-all`.
+
+```js
+watchAll()
+```


### PR DESCRIPTION
## Override dev server configuration
 To override the webpack dev server configuration, you can use the `overrideDevServer` utility:
 ```js
const {
  override,
  disableEsLint,
  overrideDevServer,
  watchAll
} = require("customize-cra");
 module.exports = {
  webpack: override(
    // usual webpack plugin
    disableEsLint()
  ),
  devServer: overrideDevServer(
    // dev server plugin
    watchAll()
  )
};
```
 ### watchAll()
 When applied, CRA will watch all the project's files, included `node_modules`.  
To use it, just apply it and run the dev server with `yarn start --watch-all`.
 ```js
watchAll()
```