### PR TITLE
useEslintRc - allow to specify eslint config path

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,13 +90,15 @@ const adjustWorkbox = adjust => config => {
   return config;
 };
 
-const useEslintRc = () => config => {
+const useEslintRc = configFile => config => {
   const eslintRule = config.module.rules.filter(
     r => r.use && r.use.some(u => u.options && u.options.useEslintrc !== void 0)
   )[0];
 
   eslintRule.use[0].options.useEslintrc = true;
   eslintRule.use[0].options.ignore = true;
+  eslintRule.use[0].options.configFile = configFile;
+
   delete eslintRule.use[0].options.baseConfig;
 
   const rules = config.module.rules.map(r =>

--- a/readme.md
+++ b/readme.md
@@ -133,9 +133,10 @@ If you want use `@babel/plugin-proposal-decorators` with EsLint, you can enable 
 }
 ```
 
-### useEslintRc()
+### useEslintRc(configFile)
 
 Causes your .eslintrc file to be used, rather than the config CRA ships with.
+`configFile` is an optional parameter that allows to specify the exact path to the ESLint configuration file.
 
 ### enableEslintTypescript()
 


### PR DESCRIPTION
This change resolves also the problem when default `.eslintrc` file from the project's root is not loaded.
Specifying the `configFile` loader option to `undefined` (default parameter value) lets eslint loader to search for configuration file in the root directory.