### PR TITLE
test: add coverage for remaining public exports

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,7 +329,7 @@ const removeModuleScopePlugin = () => config => {
 const addTslintLoader = options => config => {
   config.module.rules.unshift({
     test: /\.(ts|tsx)$/,
-    loader: require.resolve("tslint-loader"),
+    loader: "tslint-loader",
     options,
     enforce: "pre"
   });

--- a/test.js
+++ b/test.js
@@ -6,7 +6,11 @@ const {
   addBabelPresets,
   fixBabelImports,
   useBabelRc,
-  babelInclude
+  babelInclude,
+  addWebpackExternals,
+  addWebpackAlias,
+  addWebpackResolve,
+  addWebpackPlugin
 } = require(".");
 
 describe("babel", () => {
@@ -309,5 +313,78 @@ describe("babel", () => {
         ]
       }
     });
+  });
+});
+
+describe("webpack", () => {
+  test("addWebpackExternals returns function that spreads provided args last in externals list", () => {
+    const config = {
+      externals: { lodash: "Lodash", "react-dom": "NotReactDom" }
+    };
+    const externals = {
+      react: "React",
+      "react-dom": "ReactDom"
+    };
+    const outputConfig = addWebpackExternals(externals)(config);
+
+    expect(outputConfig).toMatchObject({
+      externals: {
+        lodash: "Lodash",
+        react: "React",
+        "react-dom": "ReactDom"
+      }
+    });
+  });
+
+  describe("addWebpackAlias", () => {
+    test("initializes resolve.alias with empty objects if non-existant", () => {
+      const config = {};
+      const outputConfig = addWebpackAlias({})(config);
+
+      expect(outputConfig).toEqual({ resolve: { alias: {} } });
+    });
+
+    test("merges the provided alias object with the config resolve.alias object", () => {
+      const config = {
+        resolve: {
+          alias: { a: "A", b: "B" }
+        }
+      };
+      const alias = { b: "b", c: "c" };
+      const outputConfig = addWebpackAlias(alias)(config);
+
+      expect(outputConfig).toEqual({
+        resolve: { alias: { a: "A", b: "b", c: "c" } }
+      });
+    });
+  });
+
+  describe("addWebpackResolve", () => {
+    test("initializes resolve with empty object if non-existant", () => {
+      const config = {};
+      const outputConfig = addWebpackResolve({})(config);
+
+      expect(outputConfig).toEqual({ resolve: {} });
+    });
+
+    test("merges the provided resolve object into the config resolve object", () => {
+      const config = {
+        resolve: {
+          alias: { a: "A", b: "b" }
+        }
+      };
+      const resolve = { alias: { a: "a", b: "B" } };
+      const outputConfig = addWebpackResolve(resolve)(config);
+
+      expect(outputConfig).toEqual({ resolve: { alias: { a: "a", b: "B" } } });
+    });
+  });
+
+  test("addWebpackPlugin adds the provided plugin to the config plugins list", () => {
+    const config = {
+      plugins: ["A"]
+    };
+    const plugin = "B";
+    const outputConfig = addWebpackPlugin(plugin)(config);
   });
 });

--- a/test.js
+++ b/test.js
@@ -10,7 +10,8 @@ const {
   addWebpackExternals,
   addWebpackAlias,
   addWebpackResolve,
-  addWebpackPlugin
+  addWebpackPlugin,
+  override
 } = require(".");
 
 describe("babel", () => {
@@ -387,4 +388,15 @@ describe("webpack", () => {
     const plugin = "B";
     const outputConfig = addWebpackPlugin(plugin)(config);
   });
+});
+
+test("override composes provided plugin functions", () => {
+  const plugin1 = jest.fn(x => x);
+  const plugin2 = jest.fn(x => x);
+  const composed = override(plugin1, plugin2);
+  const result = composed("hello");
+
+  expect(result).toBe("hello");
+  expect(plugin1).toHaveBeenCalledWith("hello");
+  expect(plugin2).toHaveBeenCalledWith("hello");
 });

--- a/test.js
+++ b/test.js
@@ -7,6 +7,7 @@ const {
   fixBabelImports,
   useBabelRc,
   babelInclude,
+  addDecoratorsLegacy,
   addWebpackExternals,
   addWebpackAlias,
   addWebpackResolve,
@@ -308,6 +309,34 @@ describe("babel", () => {
               {
                 loader: "babel",
                 options: { presets }
+              }
+            ]
+          }
+        ]
+      }
+    });
+  });
+
+  test("addDecoratorsLegacy returns a function that adds the decorators plugin to the plugins list", () => {
+    const inputConfig = {
+      module: {
+        rules: [{ oneOf: [{ loader: "babel", options: { plugins: [] } }] }]
+      }
+    };
+    const outputConfig = addDecoratorsLegacy()(inputConfig);
+
+    expect(outputConfig).toMatchObject({
+      module: {
+        rules: [
+          {
+            oneOf: [
+              {
+                loader: "babel",
+                options: {
+                  plugins: [
+                    ["@babel/plugin-proposal-decorators", { legacy: true }]
+                  ]
+                }
               }
             ]
           }


### PR DESCRIPTION
# 🔬 The one where we test most of the `function`s

This PR adds basic unit tests for most remaining untested non-`babel` functions. Having test coverage will provide us some safety in doing work, refactoring, fixing docs, etc.

This PR does not test `addBundleVisualizer` due to the external dep `require('webpack-bundle-analyzer')`, which isn't installed and so cant' be mocked. Not sure how to handle that without adding it as a `devDep`, which feels so dumb. Any ideas?

It also doesn't test `addPostcssPlugins` because the function has external dependencies and is complex, so I'll follow-up with a PR later refactoring it some to make it more understandable and testable.

## Completion
- [x] override
- [x] addBundleVisualizer (*not tested*, has unresolvable external dep on `require('webpack-bundle-analyzer')`)
- [x] addDecoratorsLegacy
- [x] addWebpackExternals
- [x] disableEsLint
- [x] addWebpackAlias
- [x] addWebpackResolve
- [x] addWebpackPlugin
- [x] adjustWorkbox
- [x] useEslintRc
- [x] enableEslintTypescript
- [x] addLessLoader
- [x] overrideDevServer
- [x] watchAll
- [x] disableChunk
- [x] addPostcssPlugins (*not tested*, will follow-up due to complexity and external deps)
- [x] removeModuleScopePlugin
- [x] addTslintLoader