### PR TITLE
chore(jest): convert tests to snapshots

### DIFF
--- a/src/__snapshots__/utilities.test.js.snap
+++ b/src/__snapshots__/utilities.test.js.snap
@@ -1,0 +1,23 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getBabelLoader finds the babel loader options in "oneOf" array 1`] = `
+Object {
+  "loader": "babel",
+  "options": Object {
+    "plugins": Array [
+      "test",
+    ],
+  },
+}
+`;
+
+exports[`getBabelLoader finds the babel loader options in a rule's "use" array 1`] = `
+Object {
+  "loader": "babel",
+  "options": Object {
+    "plugins": Array [
+      "test",
+    ],
+  },
+}
+`;

--- a/src/customizers/__snapshots__/babel.test.js.snap
+++ b/src/customizers/__snapshots__/babel.test.js.snap
@@ -1,0 +1,195 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addBabelPlugin returns a function that adds a plugin to the plugins list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [
+                "@babel/plugin-transform-runtime",
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`addBabelPlugins returns functions that add plugins to the plugins list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [
+                Array [
+                  "@babel/plugin-proposal-object-rest-spread",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "@babel/plugin-transform-runtime",
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`addBabelPreset returns a function that adds a preset to the presets list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [],
+              "presets": Array [
+                "@babel/env",
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`addBabelPresets returns functions that add presets to the presets list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [],
+              "presets": Array [
+                Array [
+                  "@babel/env",
+                  Object {
+                    "loose": true,
+                  },
+                ],
+                "@babel/typescript",
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`addDecoratorsLegacy returns a function that adds the decorators plugin to the plugins list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [
+                Array [
+                  "@babel/plugin-proposal-decorators",
+                  Object {
+                    "legacy": true,
+                  },
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`babelInclude sets the babel loader include 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "include": Array [
+              "src",
+            ],
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`fixBabelImports adds the babel imports plugin for the provided library 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "plugins": Array [
+                Array [
+                  "import",
+                  Object {
+                    "libraryDirectory": "",
+                    "libraryName": "lodash",
+                  },
+                  "fix-lodash-imports",
+                ],
+              ],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`useBabelRc enables the babel loader's babelrc flag 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "loader": "babel",
+            "options": Object {
+              "babelrc": true,
+              "plugins": Array [],
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/src/customizers/__snapshots__/webpack.test.js.snap
+++ b/src/customizers/__snapshots__/webpack.test.js.snap
@@ -1,0 +1,168 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`addPostcssPlugins adds postcss plugins to the postcss rule 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "oneOf": Array [
+          Object {
+            "use": Array [
+              Object {
+                "options": Object {
+                  "ident": "postcss",
+                  "plugins": [Function],
+                },
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`addWebpackAlias initializes resolve.alias with empty objects if non-existant 1`] = `
+Object {
+  "resolve": Object {
+    "alias": Object {},
+  },
+}
+`;
+
+exports[`addWebpackAlias merges the provided alias object with the config resolve.alias object 1`] = `
+Object {
+  "resolve": Object {
+    "alias": Object {
+      "a": "A",
+      "b": "b",
+      "c": "c",
+    },
+  },
+}
+`;
+
+exports[`addWebpackExternals returns function that spreads provided args last in externals list 1`] = `
+Object {
+  "externals": Object {
+    "lodash": "Lodash",
+    "react": "React",
+    "react-dom": "ReactDom",
+  },
+}
+`;
+
+exports[`addWebpackPlugin adds the provided plugin to the config plugins list 1`] = `
+Object {
+  "plugins": Array [
+    "A",
+    "B",
+  ],
+}
+`;
+
+exports[`addWebpackResolve initializes resolve with empty object if non-existant 1`] = `
+Object {
+  "resolve": Object {},
+}
+`;
+
+exports[`addWebpackResolve merges the provided resolve object into the config resolve object 1`] = `
+Object {
+  "resolve": Object {
+    "alias": Object {
+      "a": "a",
+      "b": "B",
+    },
+  },
+}
+`;
+
+exports[`adjustWorkbox calls the provided adjustment using the workbox plugin config 1`] = `
+Object {
+  "plugins": Array [
+    Object {
+      "config": Object {
+        "test": true,
+      },
+      "constructor": Object {
+        "name": "GenerateSW",
+      },
+    },
+  ],
+}
+`;
+
+exports[`disableChunk disables chunking config options 1`] = `
+Object {
+  "optimization": Object {
+    "runtimeChunk": false,
+    "splitChunks": Object {
+      "cacheGroups": Object {
+        "default": false,
+      },
+    },
+  },
+}
+`;
+
+exports[`eslint addTslintLoader adds tslint-loader as the first rule 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "enforce": "pre",
+        "loader": "tslint-loader",
+        "options": Object {
+          "test": true,
+        },
+        "test": /\\\\\\.\\(ts\\|tsx\\)\\$/,
+      },
+      Object {
+        "test": true,
+      },
+    ],
+  },
+}
+`;
+
+exports[`eslint disableEsLint filters out the eslint rules from the config rules list 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [],
+  },
+}
+`;
+
+exports[`eslint useEslintRc removes the base eslint config and uses the passed filename instead 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "use": Array [
+          Object {
+            "options": Object {
+              "configFile": ".eslintrc",
+              "ignore": true,
+              "useEslintrc": true,
+            },
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`removeModuleScopePlugin removes the 'ModuleScopePlugin' resolve plugin 1`] = `
+Object {
+  "resolve": Object {
+    "plugins": Array [
+      Object {
+        "test": true,
+      },
+    ],
+  },
+}
+`;

--- a/src/customizers/babel.test.js
+++ b/src/customizers/babel.test.js
@@ -9,301 +9,87 @@ const {
   babelInclude
 } = require("./babel");
 
-describe("babel", () => {
-  test("fixBabelImports adds the babel imports plugin for the provided library", () => {
-    const options = { libraryDirectory: "" };
-    const plugin = [
-      "import",
-      { libraryDirectory: "", libraryName: "lodash" },
-      "fix-lodash-imports"
-    ];
-    const config = {
-      module: {
-        rules: [
+const config = () => ({
+  module: {
+    rules: [
+      {
+        oneOf: [
           {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: []
-                }
-              }
-            ]
+            loader: "babel",
+            options: {
+              plugins: []
+            }
           }
         ]
       }
-    };
+    ]
+  }
+});
 
-    expect(fixBabelImports("lodash", options)(config)).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: [plugin]
-                }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("fixBabelImports adds the babel imports plugin for the provided library", () => {
+  const options = { libraryDirectory: "" };
+  const plugin = [
+    "import",
+    { libraryDirectory: "", libraryName: "lodash" },
+    "fix-lodash-imports"
+  ];
+  const actual = fixBabelImports("lodash", options)(config());
 
-  test("useBabelRc enables the babel loader's babelrc flag", () => {
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: [],
-                  babelrc: false
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(useBabelRc()(config)).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  babelrc: true
-                }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("useBabelRc enables the babel loader's babelrc flag", () => {
+  const actual = useBabelRc()(config());
 
-  test("babelInclude sets the babel loader include", () => {
-    const include = ["src"];
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: []
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(babelInclude(include)(config)).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                include
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("babelInclude sets the babel loader include", () => {
+  const include = ["src"];
+  const actual = babelInclude(include)(config());
 
-  test("addBabelPlugin returns a function that adds a plugin to the plugins list", () => {
-    const plugin = "@babel/plugin-transform-runtime";
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: []
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(addBabelPlugin(plugin)(config)).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: { plugins: [plugin] }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("addBabelPlugin returns a function that adds a plugin to the plugins list", () => {
+  const plugin = "@babel/plugin-transform-runtime";
+  const actual = addBabelPlugin(plugin)(config());
 
-  test("addBabelPlugins returns functions that add plugins to the plugins list", () => {
-    const plugins = [
-      ["@babel/plugin-proposal-object-rest-spread", { loose: true }],
-      "@babel/plugin-transform-runtime"
-    ];
-    const inputConfig = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: []
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
-    const functions = addBabelPlugins(...plugins);
-    const outputConfig = functions.reduce(
-      (config, fn) => fn(config),
-      inputConfig
-    );
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(outputConfig).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: { plugins }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("addBabelPlugins returns functions that add plugins to the plugins list", () => {
+  const plugins = [
+    ["@babel/plugin-proposal-object-rest-spread", { loose: true }],
+    "@babel/plugin-transform-runtime"
+  ];
+  const functions = addBabelPlugins(...plugins);
+  const actual = functions.reduce((config, fn) => fn(config), config());
 
-  test("addBabelPreset returns a function that adds a preset to the presets list", () => {
-    const preset = "@babel/env";
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: [],
-                  presets: []
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(addBabelPreset(preset)(config)).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: { presets: [preset] }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("addBabelPreset returns a function that adds a preset to the presets list", () => {
+  const preset = "@babel/env";
+  const conf = config();
+  conf.module.rules[0].oneOf[0].options.presets = [];
+  const actual = addBabelPreset(preset)(conf);
 
-  test("addBabelPresets returns functions that add presets to the presets list", () => {
-    const presets = [["@babel/env", { loose: true }], "@babel/typescript"];
-    const inputConfig = {
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: [],
-                  presets: []
-                }
-              }
-            ]
-          }
-        ]
-      }
-    };
-    const functions = addBabelPresets(...presets);
-    const outputConfig = functions.reduce(
-      (config, fn) => fn(config),
-      inputConfig
-    );
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(outputConfig).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: { presets }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("addBabelPresets returns functions that add presets to the presets list", () => {
+  const presets = [["@babel/env", { loose: true }], "@babel/typescript"];
+  const conf = config();
+  conf.module.rules[0].oneOf[0].options.presets = [];
+  const functions = addBabelPresets(...presets);
+  const actual = functions.reduce((config, fn) => fn(config), conf);
 
-  test("addDecoratorsLegacy returns a function that adds the decorators plugin to the plugins list", () => {
-    const inputConfig = {
-      module: {
-        rules: [{ oneOf: [{ loader: "babel", options: { plugins: [] } }] }]
-      }
-    };
-    const outputConfig = addDecoratorsLegacy()(inputConfig);
+  expect(actual).toMatchSnapshot();
+});
 
-    expect(outputConfig).toMatchObject({
-      module: {
-        rules: [
-          {
-            oneOf: [
-              {
-                loader: "babel",
-                options: {
-                  plugins: [
-                    ["@babel/plugin-proposal-decorators", { legacy: true }]
-                  ]
-                }
-              }
-            ]
-          }
-        ]
-      }
-    });
-  });
+test("addDecoratorsLegacy returns a function that adds the decorators plugin to the plugins list", () => {
+  const actual = addDecoratorsLegacy()(config());
+
+  expect(actual).toMatchSnapshot();
 });

--- a/src/customizers/webpack.test.js
+++ b/src/customizers/webpack.test.js
@@ -14,81 +14,56 @@ const {
   addPostcssPlugins
 } = require("./webpack");
 
-describe("webpack", () => {
-  test("addWebpackExternals returns function that spreads provided args last in externals list", () => {
-    const config = {
-      externals: { lodash: "Lodash", "react-dom": "NotReactDom" }
-    };
-    const externals = {
-      react: "React",
-      "react-dom": "ReactDom"
-    };
-    const outputConfig = addWebpackExternals(externals)(config);
+test("addWebpackExternals returns function that spreads provided args last in externals list", () => {
+  const config = {
+    externals: { lodash: "Lodash", "react-dom": "NotReactDom" }
+  };
+  const externals = { react: "React", "react-dom": "ReactDom" };
+  const actual = addWebpackExternals(externals)(config);
 
-    expect(outputConfig).toMatchObject({
-      externals: {
-        lodash: "Lodash",
-        react: "React",
-        "react-dom": "ReactDom"
-      }
-    });
+  expect(actual).toMatchSnapshot();
+});
+
+describe("addWebpackAlias", () => {
+  test("initializes resolve.alias with empty objects if non-existant", () => {
+    const config = {};
+    const actual = addWebpackAlias({})(config);
+
+    expect(actual).toMatchSnapshot();
   });
 
-  describe("addWebpackAlias", () => {
-    test("initializes resolve.alias with empty objects if non-existant", () => {
-      const config = {};
-      const outputConfig = addWebpackAlias({})(config);
+  test("merges the provided alias object with the config resolve.alias object", () => {
+    const config = { resolve: { alias: { a: "A", b: "B" } } };
+    const alias = { b: "b", c: "c" };
+    const actual = addWebpackAlias(alias)(config);
 
-      expect(outputConfig).toEqual({ resolve: { alias: {} } });
-    });
+    expect(actual).toMatchSnapshot();
+  });
+});
 
-    test("merges the provided alias object with the config resolve.alias object", () => {
-      const config = {
-        resolve: {
-          alias: { a: "A", b: "B" }
-        }
-      };
-      const alias = { b: "b", c: "c" };
-      const outputConfig = addWebpackAlias(alias)(config);
+describe("addWebpackResolve", () => {
+  test("initializes resolve with empty object if non-existant", () => {
+    const config = {};
+    const actual = addWebpackResolve({})(config);
 
-      expect(outputConfig).toEqual({
-        resolve: { alias: { a: "A", b: "b", c: "c" } }
-      });
-    });
+    expect(actual).toMatchSnapshot();
   });
 
-  describe("addWebpackResolve", () => {
-    test("initializes resolve with empty object if non-existant", () => {
-      const config = {};
-      const outputConfig = addWebpackResolve({})(config);
+  test("merges the provided resolve object into the config resolve object", () => {
+    const config = { resolve: { alias: { a: "A", b: "b" } } };
+    const resolve = { alias: { a: "a", b: "B" } };
+    const actual = addWebpackResolve(resolve)(config);
 
-      expect(outputConfig).toEqual({ resolve: {} });
-    });
-
-    test("merges the provided resolve object into the config resolve object", () => {
-      const config = {
-        resolve: {
-          alias: { a: "A", b: "b" }
-        }
-      };
-      const resolve = { alias: { a: "a", b: "B" } };
-      const outputConfig = addWebpackResolve(resolve)(config);
-
-      expect(outputConfig).toEqual({ resolve: { alias: { a: "a", b: "B" } } });
-    });
+    expect(actual).toMatchSnapshot();
   });
+});
 
-  test("addWebpackPlugin adds the provided plugin to the config plugins list", () => {
-    const config = {
-      plugins: ["A"]
-    };
-    const plugin = "B";
-    const outputConfig = addWebpackPlugin(plugin)(config);
+test("addWebpackPlugin adds the provided plugin to the config plugins list", () => {
+  const config = { plugins: ["A"] };
+  const plugin = "B";
+  const actual = addWebpackPlugin(plugin)(config);
 
-    expect(outputConfig).toEqual({
-      plugins: ["A", "B"]
-    });
-  });
+  expect(actual).toMatchSnapshot();
 });
 
 describe("eslint", () => {
@@ -96,9 +71,9 @@ describe("eslint", () => {
     const inputConfig = {
       module: { rules: [{ use: [{ options: { useEslintrc: true } }] }] }
     };
-    const outputConfig = disableEsLint()(inputConfig);
+    const actual = disableEsLint()(inputConfig);
 
-    expect(outputConfig).toEqual({ module: { rules: [] } });
+    expect(actual).toMatchSnapshot();
   });
 
   test("useEslintRc removes the base eslint config and uses the passed filename instead", () => {
@@ -114,27 +89,17 @@ describe("eslint", () => {
         ]
       }
     };
-    const outputConfig = useEslintRc(configFile)(inputConfig);
+    const actual = useEslintRc(configFile)(inputConfig);
 
-    expect(outputConfig).toEqual({
-      module: {
-        rules: [
-          {
-            use: [{ options: { useEslintrc: true, ignore: true, configFile } }]
-          }
-        ]
-      }
-    });
+    expect(actual).toMatchSnapshot();
   });
 
   describe("enableEslintTypescript adds /tsx?/ to eslint file pattern test config ", () => {
     const inputConfig = {
-      module: {
-        rules: [{ use: [{ options: { useEslintrc: false } }] }]
-      }
+      module: { rules: [{ use: [{ options: { useEslintrc: false } }] }] }
     };
-    const outputConfig = enableEslintTypescript()(inputConfig);
-    const regex = outputConfig.module.rules[0].test;
+    const actual = enableEslintTypescript()(inputConfig);
+    const regex = actual.module.rules[0].test;
     const validExtensions = ["js", "jsx", "ts", "tsx", "mjs"];
 
     validExtensions.forEach(extension => {
@@ -146,12 +111,11 @@ describe("eslint", () => {
 
   test("addTslintLoader adds tslint-loader as the first rule", () => {
     const options = { test: true };
-    const inputConfig = {
-      module: { rules: [{ test: true }] }
-    };
-    const outputConfig = addTslintLoader(options)(inputConfig);
+    const inputConfig = { module: { rules: [{ test: true }] } };
+    const actual = addTslintLoader(options)(inputConfig);
 
-    expect(outputConfig).toEqual(
+    expect(actual).toMatchSnapshot();
+    expect(actual).toEqual(
       expect.objectContaining({
         module: {
           rules: [
@@ -175,8 +139,9 @@ test("adjustWorkbox calls the provided adjustment using the workbox plugin confi
   const inputConfig = {
     plugins: [{ constructor: { name: "GenerateSW" }, config: innerConfig }]
   };
+  const actual = adjustWorkbox(adjustment)(inputConfig);
 
-  expect(adjustWorkbox(adjustment)(inputConfig)).toEqual(inputConfig);
+  expect(actual).toMatchSnapshot();
   expect(adjustment).toHaveBeenCalledWith(innerConfig);
 });
 
@@ -198,13 +163,9 @@ test("disableChunk disables chunking config options", () => {
       runtimeChunk: true
     }
   };
+  const actual = disableChunk()(inputConfig);
 
-  expect(disableChunk()(inputConfig)).toEqual({
-    optimization: {
-      splitChunks: { cacheGroups: { default: false } },
-      runtimeChunk: false
-    }
-  });
+  expect(actual).toMatchSnapshot();
 });
 
 test("addPostcssPlugins adds postcss plugins to the postcss rule", () => {
@@ -224,22 +185,10 @@ test("addPostcssPlugins adds postcss plugins to the postcss rule", () => {
       ]
     }
   };
-  const outputConfig = addPostcssPlugins(plugins)(inputConfig);
+  const actual = addPostcssPlugins(plugins)(inputConfig);
 
-  expect(outputConfig).toMatchObject({
-    module: {
-      rules: [
-        {
-          oneOf: [
-            {
-              use: [{ options: { plugins: expect.any(Function) } }]
-            }
-          ]
-        }
-      ]
-    }
-  });
-  const result = outputConfig.module.rules[0].oneOf[0].use[0].options
+  expect(actual).toMatchSnapshot();
+  const result = actual.module.rules[0].oneOf[0].use[0].options
     .plugins()
     .forEach(p => p());
   expect(plugin1).toHaveBeenCalled();
@@ -252,8 +201,7 @@ test("removeModuleScopePlugin removes the 'ModuleScopePlugin' resolve plugin", (
       plugins: [{ constructor: { name: "ModuleScopePlugin" } }, { test: true }]
     }
   };
+  const actual = removeModuleScopePlugin()(inputConfig);
 
-  expect(removeModuleScopePlugin()(inputConfig)).toEqual({
-    resolve: { plugins: [{ test: true }] }
-  });
+  expect(actual).toMatchSnapshot();
 });

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -4,30 +4,12 @@ describe("getBabelLoader finds the babel loader options", () => {
   const loader = { loader: "babel", options: { plugins: ["test"] } };
 
   test('in "oneOf" array', () => {
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [loader]
-          }
-        ]
-      }
-    };
-
-    expect(getBabelLoader(config)).toEqual(loader);
+    const config = { module: { rules: [{ oneOf: [loader] }] } };
+    expect(getBabelLoader(config)).toMatchSnapshot();
   });
 
   test('in a rule\'s "use" array', () => {
-    const config = {
-      module: {
-        rules: [
-          {
-            oneOf: [{ use: [loader] }]
-          }
-        ]
-      }
-    };
-
-    expect(getBabelLoader(config)).toEqual(loader);
+    const config = { module: { rules: [{ oneOf: [{ use: [loader] }] }] } };
+    expect(getBabelLoader(config)).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
This PR closes #119 by converting the tests for `utilities` and `customizers` to snapshot tests. Since the outcome of each function represents a single transformation of the config file, a snapshot diff will make it very clear what part of the transformation is failing.

Note that this doesn't mean we shouldn't test other things (side effects, etc.), only that we want to always test against the produced config to make sure the expected transformation occurs.