### PR TITLE
feat: add addWebpackModuleRule customizer

### DIFF
--- a/api.md
+++ b/api.md
@@ -135,6 +135,20 @@ addWebpackExternals({
 
 `addWebpackExternals` can also accept a `string`, `function`, or `regex`. See [the webpack documentation](https://webpack.js.org/configuration/externals/) for more information.
 
+### addWebpackModuleRule(rule)
+
+Adds the provided rule to the webpack config's `module.rules` array.
+
+See https://webpack.js.org/configuration/module/#modulerules for more information
+
+```js
+module.exports = {
+  override(
+    addWebpackModuleRule({text: /\.txt$/, use: 'raw-loader'})
+  )
+}
+```
+
 ### addBundleVisualizer(options, behindFlag = false)
 
 Adds the bundle visualizer plugin to your webpack config. Be sure to have `webpack-bundle-analyzer` installed. By default, the options passed to the plugin will be:
@@ -365,7 +379,7 @@ module.exports = override(
   disableEsLint(),
   ...addExternalBabelPlugins(
     "babel-plugin-transform-do-expressions",
-    "@babel/plugin-proposal-object-rest-spread",
+    "@babel/plugin-proposal-object-rest-spread"
   ),
   fixBabelImports("lodash", {
     libraryDirectory: "",

--- a/src/customizers/__snapshots__/webpack.test.js.snap
+++ b/src/customizers/__snapshots__/webpack.test.js.snap
@@ -57,6 +57,18 @@ Object {
 }
 `;
 
+exports[`addWebpackModuleRule adds the provided rule to module.rules 1`] = `
+Object {
+  "module": Object {
+    "rules": Array [
+      Object {
+        "name": "__TEST__",
+      },
+    ],
+  },
+}
+`;
+
 exports[`addWebpackPlugin adds the provided plugin to the config plugins list 1`] = `
 Object {
   "plugins": Array [

--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -217,20 +217,18 @@ export const addWebpackExternals = externalDeps => config => {
   let externals = config.externals;
   if (!externals) {
     externals = externalDeps;
-
   } else if (Array.isArray(externalDeps)) {
     externals = externalDeps.concat(externals);
-
-  } else if (Array.isArray(externals)
-    || externalDeps.constructor === Function
-    || externalDeps.constructor === RegExp) {
+  } else if (
+    Array.isArray(externals) ||
+    externalDeps.constructor === Function ||
+    externalDeps.constructor === RegExp
+  ) {
     externals = [externalDeps].concat(externals);
-
-  } else if (externalDeps instanceof Object
-    && externals instanceof Object) {
+  } else if (externalDeps instanceof Object && externals instanceof Object) {
     externals = {
       ...externals,
-      ...externalDeps,
+      ...externalDeps
     };
   }
 
@@ -265,6 +263,17 @@ export const removeModuleScopePlugin = () => config => {
   config.resolve.plugins = config.resolve.plugins.filter(
     p => p.constructor.name !== "ModuleScopePlugin"
   );
+  return config;
+};
+
+/**
+ * Add the provided module to the webpack module rules array.
+ *
+ * @param rule The rule to be added
+ * @see https://webpack.js.org/configuration/module/#modulerules
+ */
+export const addWebpackModuleRule = rule => config => {
+  config.module.rules.push(rule);
   return config;
 };
 

--- a/src/customizers/webpack.test.js
+++ b/src/customizers/webpack.test.js
@@ -7,6 +7,7 @@ import {
   useEslintRc,
   enableEslintTypescript,
   addTslintLoader,
+  addWebpackModuleRule,
   adjustWorkbox,
   watchAll,
   disableChunk,
@@ -22,7 +23,7 @@ test("addWebpackExternals returns function that spreads provided args last in ex
   const extReg = /^(jquery|\$)$/i;
   function extFun(context, request, callback) {
     if (/^yourregex$/.test(request)) {
-      return callback(null, 'commonjs ' + request);
+      return callback(null, "commonjs " + request);
     }
     callback();
   }
@@ -140,6 +141,14 @@ describe("eslint", () => {
       })
     );
   });
+});
+
+test("addWebpackModuleRule adds the provided rule to module.rules", () => {
+  const rule = { name: "__TEST__" };
+  const inputConfig = { module: { rules: [] } };
+  const actual = addWebpackModuleRule(rule)(inputConfig);
+
+  expect(actual).toMatchSnapshot();
 });
 
 test("adjustWorkbox calls the provided adjustment using the workbox plugin config", () => {


### PR DESCRIPTION
This change adds the `addWebpackModuleRule` customizer, which allows a
user to provide a rule which that will be added to the webpack config's
`module.rules` array.

Closes #137