### PR TITLE
fix api doc for setWebpackOptimizationSplitChunks

### DIFF
--- a/api.md
+++ b/api.md
@@ -26,7 +26,7 @@ This file documents the functions exported by `customize-cra`.
   - [setWebpackTarget](#setwebpacktargettarget)
   - [setWebpackStats](#setwebpackstats)
   - [addBundleVisualizer](#addbundlevisualizeroptions-behindflag--false)
-  - [setWebpackOptimizationSplitChunks](#setwebpackoptimizationsplitchunks)
+  - [setWebpackOptimizationSplitChunks](#setwebpackoptimizationsplitchunkstarget)
   - [adjustWorkbox](#adjustworkboxfn)
   - [addLessLoader](#addlessloaderloaderoptions)
   - [addPostcssPlugins](#addpostcsspluginsplugins)


### PR DESCRIPTION
fix api doc for `setWebpackOptimizationSplitChunks` method. BTW, this method does not publish on the latest release, but it appear in the api doc of master branch. This makes me confused when I call `setWebpackOptimizationSplitChunks` method.