### PR TITLE
Fix compile error from css-loader 3

### DIFF
--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -190,8 +190,9 @@ export const addLessLoader = (loaderOptions = {}) => config => {
       test: lessModuleRegex,
       use: getLessLoader({
         importLoaders: 2,
-        modules: true,
-        localIdentName: localIdentName
+        modules: {
+          localIdentName: localIdentName
+        }
       })
     }
   );


### PR DESCRIPTION
This PR will fix https://github.com/arackaf/customize-cra/issues/199.

`css-loader` 3 changed its API. `localIdentName` should be passed in `modules`, which could be a object instead of a boolean.