### PR TITLE
feat: useBabelConfigFile

### DIFF
--- a/src/customizers/babel.js
+++ b/src/customizers/babel.js
@@ -34,6 +34,11 @@ export const babelInclude = include => config => {
   return config;
 };
 
+export const useBabelConfigFile = path => config => {
+  getBabelLoader(config).options.configFile = path;
+  return config;
+};
+
 /**
  * Replaces the `exclude` option of `babel-loader`.
  * @param exclude The new `exclude` value.


### PR DESCRIPTION
This allows using a custom babel config similar to the useBabelRc to use `.babelrc` but this allows passing in the file path.
This is required for me as jest must have a `babel.config.js` rather than a `.babelrc`