### PR TITLE
Add cb to tap utility.

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -44,7 +44,14 @@ export const tap = (options) => (config) => {
 
   if (dest) {
     const fs = require('fs')
-    fs.appendFile(dest, `${print.join('\n')}\n`)
+    fs.appendFile(
+      dest,
+      `${print.join('\n')}\n`,
+      (err) => {
+        if (err) throw new Error(err);
+        console.log(`customize-cra config written to file ${dest}`);
+      }
+    )
   }
 
   print.forEach(sentence => console.log(sentence))


### PR DESCRIPTION
As it is now, with no callback provided to `fs.appendFile`, passing a `dest` option to `tap` will result in an error `Callback must be a function` error and process will fail with exit code 1. This change gives a cb to throw an error if `fs.appendFile` results in an error and log a confirmation message on success.