### PR TITLE
feat: Enhance addLessLoader

### DIFF
--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -118,14 +118,21 @@ export const enableEslintTypescript = () => config => {
   return config;
 };
 
-export const addLessLoader = (loaderOptions = {}) => config => {
+export const addLessLoader = (loaderOptions = {}, customCssModules = {}) => config => {
   const MiniCssExtractPlugin = require("mini-css-extract-plugin");
   const postcssNormalize = require("postcss-normalize");
 
   const cssLoaderOptions = loaderOptions.cssLoaderOptions || {};
-  const cssModules = loaderOptions.cssModules || {
-    localIdentName: "[local]--[hash:base64:5]"
-  };
+
+  const { localIdentName } = loaderOptions;
+  let cssModules = loaderOptions.cssModules || { localIdentName };
+
+  if (!cssModules.localIdentName) {
+    cssModules = customCssModules;
+  }
+
+  cssModules.localIdentName = cssModules.localIdentName || "[local]--[hash:base64:5]";
+
   const lessRegex = /\.less$/;
   const lessModuleRegex = /\.module\.less$/;
 


### PR DESCRIPTION
Support 4 ways to specific css-modules config.
1.  Use "[local]--[hash:base64:5]" as default `localIdentName`
```
addLessLoader()
```
2. Compatible with the old way
```
addLessLoader({
  localIdentName: "[local]--[hash:base64:5]",
  // can't deal with getIdentName
}); 
```
3. Use cssModules property in loaderOptions
```
addLessLoader({
  ...,
  cssModules: {
    localIdentName: "[local]--[hash:base64:5]",
    ...
  }
}); 

```
4. Use optional param customCssModules
```
addLessLoader({},  {
  localIdentName: "[local]--[hash:base64:5]",
  ...
}); 

```