### PR TITLE
docs: remove unrelated duplicate text

### DIFF
--- a/api.md
+++ b/api.md
@@ -310,12 +310,6 @@ Sets your customized optimization.splitChunks configuration to your webpack conf
 }
 ```
 
-You can hide this plugin behind a command line flag (`--analyze`) by passing `true` as second argument.
-
-```js
-addBundleVisualizer({}, true);
-```
-
 ### useBabelRc()
 
 Causes your .babelrc (or .babelrc.js) file to be used, this is especially useful


### PR DESCRIPTION
There was an extra paragraph which seems to have been mistakenly copied from the previous section above it.