### PR TITLE
Fix `addLessLoader` on newer `css-loader` packages

### DIFF
--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -190,8 +190,9 @@ export const addLessLoader = (loaderOptions = {}) => config => {
       test: lessModuleRegex,
       use: getLessLoader({
         importLoaders: 2,
-        modules: true,
-        localIdentName: localIdentName
+        modules: {
+          localIdentName: localIdentName
+        },
       })
     }
   );


### PR DESCRIPTION
`css-loader` has deprecated the `localIdentName` as a direct option. It now resides within the `modules` option object.

[here](https://github.com/webpack-contrib/css-loader#localidentname)