### PR TITLE
Fix `tap({dest: ...})`

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -163,6 +163,15 @@
         "code",
         "doc"
       ]
+    },
+    {
+      "login": "davidsheldon",
+      "name": "David Sheldon",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/37772?v=4",
+      "profile": "https://github.com/davidsheldon",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # `customize-cra`
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-17-orange.svg?style=flat-square)](#contributors-)
+[![All Contributors](https://img.shields.io/badge/all_contributors-18-orange.svg?style=flat-square)](#contributors-)
 
 📌📌 **Breaking change:** With the `1.0` release of customize-cra breaking changes have been made to the `addLessLoader` customizer to support the changes to `create-react-app` in [#7876](https://github.com/facebook/create-react-app/pull/7876). Please follow the migration guide in [#253](https://github.com/arackaf/customize-cra/issues/253).
 
@@ -150,6 +150,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
     <td align="center"><a href="https://github.com/billypon"><img src="https://avatars2.githubusercontent.com/u/1763302?v=4" width="100px;" alt="billypon"/><br /><sub><b>billypon</b></sub></a><br /><a href="https://github.com/arackaf/customize-cra/commits?author=billypon" title="Code">💻</a></td>
     <td align="center"><a href="https://github.com/1123612483"><img src="https://avatars1.githubusercontent.com/u/20741541?v=4" width="100px;" alt="Juetta"/><br /><sub><b>Juetta</b></sub></a><br /><a href="https://github.com/arackaf/customize-cra/commits?author=1123612483" title="Code">💻</a></td>
     <td align="center"><a href="https://www.onlyling.com"><img src="https://avatars3.githubusercontent.com/u/9999765?v=4" width="100px;" alt="LING_ZI_QING"/><br /><sub><b>LING_ZI_QING</b></sub></a><br /><a href="https://github.com/arackaf/customize-cra/commits?author=onlyling" title="Code">💻</a> <a href="https://github.com/arackaf/customize-cra/commits?author=onlyling" title="Documentation">📖</a></td>
+    <td align="center"><a href="https://github.com/davidsheldon"><img src="https://avatars0.githubusercontent.com/u/37772?v=4" width="100px;" alt="David Sheldon"/><br /><sub><b>David Sheldon</b></sub></a><br /><a href="https://github.com/arackaf/customize-cra/commits?author=davidsheldon" title="Code">💻</a></td>
   </tr>
 </table>
 

--- a/src/utilities.js
+++ b/src/utilities.js
@@ -44,7 +44,7 @@ export const tap = (options) => (config) => {
 
   if (dest) {
     const fs = require('fs')
-    fs.appendFile(dest, `${print.join('\n')}\n`)
+    fs.appendFileSync(dest, `${print.join('\n')}\n`)
   }
 
   print.forEach(sentence => console.log(sentence))

--- a/src/utilities.test.js
+++ b/src/utilities.test.js
@@ -79,16 +79,16 @@ describe(`tap`, () => {
 
   describe(`with destination file option`, () => {
     const fs = require('fs')
-    const mockAppendFile = jest.fn()
+    const mockAppendFileSync = jest.fn()
     jest.mock('fs')
-    fs.appendFile = mockAppendFile
+    fs.appendFileSync = mockAppendFileSync
 
-    afterEach(() => mockAppendFile.mockClear())
+    afterEach(() => mockAppendFileSync.mockClear())
 
     test(`tap with no message`, () => {
       const result = tap({ dest: 'mypath' })(config)
       const expectedPrint = [expectedConfigPrint]
-      expect(mockAppendFile).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
+      expect(mockAppendFileSync).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
       expect(mockConsole.log).toHaveBeenNthCalledWith(1, expectedConfigPrint)
       expect(result).toEqual(config)
     })
@@ -96,7 +96,7 @@ describe(`tap`, () => {
     test(`tap with message but falsy value`, () => {
       const result = tap({ dest: 'mypath', message: '' })(config)
       const expectedPrint = [expectedConfigPrint]
-      expect(mockAppendFile).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
+      expect(mockAppendFileSync).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
       expect(mockConsole.log).toHaveBeenNthCalledWith(1, expectedConfigPrint)
       expect(result).toEqual(config)
     })
@@ -104,7 +104,7 @@ describe(`tap`, () => {
     test(`tap with message`, () => {
       const result = tap({ dest: 'mypath', message: 'A message I want to print before the configuration' })(config)
       const expectedPrint = ['A message I want to print before the configuration', expectedConfigPrint]
-      expect(mockAppendFile).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
+      expect(mockAppendFileSync).toHaveBeenCalledWith('mypath', `${expectedPrint.join('\n')}\n`)
       expect(mockConsole.log).toHaveBeenNthCalledWith(1, 'A message I want to print before the configuration')
       expect(mockConsole.log).toHaveBeenNthCalledWith(2, expectedConfigPrint)
       expect(result).toEqual(config)


### PR DESCRIPTION
Whenever I tried to use tap to write to a file I got error messages about callback being null.