### PR TITLE
improvement: add react-script@4.0.0 support for disableEsLint

### DIFF
--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -32,6 +32,7 @@ export const disableEsLint = () => config => {
   eslintRules.forEach(rule => {
     config.module.rules = config.module.rules.filter(r => r !== rule);
   });
+  config.plugins = config.plugins.filter(plugin => plugin.constructor.name !== "ESLintWebpackPlugin");
   return config;
 };
 


### PR DESCRIPTION
`react-scripts@4.0.0` no longer uses `eslint-loader` when building. It uses a new plugin `ESLintWebpackPlugin`.

This PR adds code to remove the `ESLintWebpackPlugin` plugin to `disableEsLint` to support `react-scripts@4.0.0`. The code to remove `eslint-loader` is not touched for backward compatibility.