### PR TITLE
fix: addPostcssPlugins dont work

### DIFF
--- a/src/customizers/webpack.js
+++ b/src/customizers/webpack.js
@@ -304,6 +304,15 @@ export const addPostcssPlugins = plugins => config => {
             u.options.plugins = () => [...originalPlugins(), ...plugins];
           }
         }
+        if (u.options && u.options.postcssOptions && u.options.postcssOptions.ident === "postcss") {
+          if (!u.options.postcssOptions.plugins) {
+            u.options.postcssOptions.plugins = () => [...plugins];
+          }
+          if (u.options.postcssOptions.plugins) {
+            const originalPlugins = u.options.postcssOptions.plugins;
+            u.options.postcssOptions.plugins = () => [...originalPlugins(), ...plugins];
+          }
+        }
       })
   );
   return config;


### PR DESCRIPTION
addPostcssPlugins dont work when react-scripts's version higher than or equal to 5.0.0